### PR TITLE
rate limiter en procesar pago

### DIFF
--- a/TallerJava/pom.xml
+++ b/TallerJava/pom.xml
@@ -138,6 +138,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.bucket4j</groupId>
+            <artifactId>bucket4j-core</artifactId>
+            <version>8.10.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/TallerJava/src/main/java/org/tallerJava/purchaseModule/interfase/remote/rest/PurchaseAPI.java
+++ b/TallerJava/src/main/java/org/tallerJava/purchaseModule/interfase/remote/rest/PurchaseAPI.java
@@ -12,6 +12,7 @@ import org.jboss.logging.Logger;
 import org.tallerJava.purchaseModule.application.PurchaseService;
 import org.tallerJava.purchaseModule.application.dto.PaymentDataDTO;
 import org.tallerJava.purchaseModule.application.dto.SalesSummaryDTO;
+import org.tallerJava.purchaseModule.interfase.remote.rest.rateLimiter.RateLimiter;
 
 @ApplicationScoped
 @Path("/purchase")
@@ -24,6 +25,7 @@ public class PurchaseAPI {
     private PurchaseService purchaseService;
 
     @POST
+    @RateLimiter(maxRequestsPerMinute = 300)
     @Transactional
     public Response processPayment(PaymentDataDTO paymentData) {
         try {

--- a/TallerJava/src/main/java/org/tallerJava/purchaseModule/interfase/remote/rest/rateLimiter/RateLimiter.java
+++ b/TallerJava/src/main/java/org/tallerJava/purchaseModule/interfase/remote/rest/rateLimiter/RateLimiter.java
@@ -1,0 +1,15 @@
+package org.tallerJava.purchaseModule.interfase.remote.rest.rateLimiter;
+
+import jakarta.ws.rs.NameBinding;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@NameBinding
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimiter {
+    int maxRequestsPerMinute() default 5;
+}
+

--- a/TallerJava/src/main/java/org/tallerJava/purchaseModule/interfase/remote/rest/rateLimiter/RateLimiterFilter.java
+++ b/TallerJava/src/main/java/org/tallerJava/purchaseModule/interfase/remote/rest/rateLimiter/RateLimiterFilter.java
@@ -53,10 +53,10 @@ public class RateLimiterFilter implements ContainerRequestFilter {
 
     private Bucket createBucket(int maxRequestsPerMinute) {
         // Creamos un bucket con capacidad máxima igual a maxRequestsPerMinute
-        // y configuramos que se recargue con esa misma cantidad cada minuto
+        // y configuramos que se recargue con esa misma cantidad cada minuto(aprox ya que refillGreedy lo maneja diferente)
         Bandwidth bucketConf = Bandwidth.builder()
                 .capacity(maxRequestsPerMinute)
-                .refillGreedy(maxRequestsPerMinute, Duration.ofMinutes(1)) // Tambien hay opcion refill intervally (distribuye la recarga de los tokens)
+                .refillGreedy(maxRequestsPerMinute, Duration.ofMinutes(1)) // refillGreedy : Reparte los tokens lo antes posible 'ver documentación'
                 .build();
 
         // Construimos y devolvemos el bucket

--- a/TallerJava/src/main/java/org/tallerJava/purchaseModule/interfase/remote/rest/rateLimiter/RateLimiterFilter.java
+++ b/TallerJava/src/main/java/org/tallerJava/purchaseModule/interfase/remote/rest/rateLimiter/RateLimiterFilter.java
@@ -1,0 +1,74 @@
+package org.tallerJava.purchaseModule.interfase.remote.rest.rateLimiter;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.time.Duration;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+
+@Provider
+@RateLimiter
+@Priority(Priorities.AUTHORIZATION)
+@Singleton
+public class RateLimiterFilter implements ContainerRequestFilter {
+
+    private static final Map<String, Bucket> BUCKET_MAP = new ConcurrentHashMap<>();
+
+    @Context
+    ResourceInfo resourceInfo;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        Method method = resourceInfo.getResourceMethod(); //Obtiene el method que está siendo invocado
+        String key = method.getDeclaringClass().getName() + "#" + method.getName(); //Debemos hacer esto ya que el filtro aplica a todos los endpoints, esta es la clave que identifica un endpoint de otro
+
+        int maxRequestsPerMinute = max_request();
+
+        // Obtener o crear un bucket para este endpoint
+        Bucket bucket = BUCKET_MAP.computeIfAbsent(key, k -> createBucket(maxRequestsPerMinute));
+
+        // Intentar consumir un token del bucket
+        if (!bucket.tryConsume(1)) {
+            // Si no hay tokens disponibles, rechazar la solicitud
+            requestContext.abortWith(
+                Response.status(Response.Status.TOO_MANY_REQUESTS)
+                    .entity("Demasiadas solicitudes. Intenta más tarde.")
+                    .build()
+            );
+        }
+    }
+
+    private Bucket createBucket(int maxRequestsPerMinute) {
+        // Creamos un bucket con capacidad máxima igual a maxRequestsPerMinute
+        // y configuramos que se recargue con esa misma cantidad cada minuto
+        Bandwidth bucketConf = Bandwidth.builder()
+                .capacity(maxRequestsPerMinute)
+                .refillGreedy(maxRequestsPerMinute, Duration.ofMinutes(1)) // Tambien hay opcion refill intervally (distribuye la recarga de los tokens)
+                .build();
+
+        // Construimos y devolvemos el bucket
+        return Bucket.builder().addLimit(bucketConf).build();
+    }
+
+    private int max_request() { // busca la anotacion a nivel de clase y de metodos
+        Method method = resourceInfo.getResourceMethod();
+        RateLimiter limiter = method.getAnnotation(RateLimiter.class);
+        if (limiter == null) {
+            limiter = resourceInfo.getResourceClass().getAnnotation(RateLimiter.class);
+        }
+        return (limiter != null) ? limiter.maxRequestsPerMinute() : 5;
+    }
+}


### PR DESCRIPTION
- Se agrega el decorador @rate_limit en el endpoint de purchasemodule --> processPayment()
- Se implementa namebinding y el decorator para poder asociarlo a un endpoint
- Se implementa el rate limiter con bucket4j